### PR TITLE
Implement sticky CTA, dark mode toggle, and refreshed hero content

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,8 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Notes
+
+- The navigation includes a dark mode toggle which persists the user preference in `localStorage` and toggles the `dark` class on the root `<html>` element.
+- A `StickyCTA` component displays a floating "Get Your Free Automation Assessment" button. On the home page it scrolls to the hero CTA; on other pages it opens the booking link directly.

--- a/src/app/about/AboutClientPage.tsx
+++ b/src/app/about/AboutClientPage.tsx
@@ -44,18 +44,11 @@ const AboutPage = () => {
               viewport={{ once: true }}
             >
               <h2 className="text-4xl font-bold text-dark mb-6">Our Story</h2>
-              <p className="text-lg text-gray-600 mb-6 leading-relaxed">
-                ZeroBusy was born from a simple observation: too many talented business owners 
-                were spending countless hours on repetitive tasks instead of growing their businesses.
-              </p>
-              <p className="text-lg text-gray-600 mb-6 leading-relaxed">
-                We saw entrepreneurs drowning in manual workflows, spending late nights on data entry, 
-                and missing opportunities because they were stuck in the operational weeds.
-              </p>
-              <p className="text-lg text-gray-600 leading-relaxed">
-                That&apos;s when we decided to build ZeroBusy - to give business owners their time back 
-                through intelligent automation that actually works.
-              </p>
+              <ul className="text-lg text-gray-600 mb-6 leading-relaxed space-y-4">
+                <li>Too many talented owners were buried in repetitive tasks instead of growth.</li>
+                <li>Manual workflows meant late nights, data entry, and missed opportunities.</li>
+                <li>We built ZeroBusy to give that time back with practical, working automation.</li>
+              </ul>
             </motion.div>
             
             <motion.div

--- a/src/app/contact/ContactForm.tsx
+++ b/src/app/contact/ContactForm.tsx
@@ -2,17 +2,20 @@
 
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
+import Link from 'next/link';
 
 const ContactPage = () => {
   const [formData, setFormData] = useState({
     name: '',
     email: '',
+    service: '',
     company: '',
     phone: '',
-    service: '',
-    message: ''
+    message: '',
+    website: ''
   });
   const [status, setStatus] = useState<'idle' | 'sending' | 'success' | 'error'>('idle');
+  const [detailsOpen, setDetailsOpen] = useState(false);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     setFormData({
@@ -23,26 +26,17 @@ const ContactPage = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (formData.website) return; // honeypot
     setStatus('sending');
     try {
-      const res = await fetch(
-        process.env.NEXT_PUBLIC_CONTACT_FORM_URL!,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(formData),
-        }
-      );
+      const res = await fetch(process.env.NEXT_PUBLIC_CONTACT_FORM_URL!, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData),
+      });
       if (res.ok) {
         setStatus('success');
-        setFormData({
-          name: '',
-          email: '',
-          company: '',
-          phone: '',
-          service: '',
-          message: '',
-        });
+        setFormData({ name: '', email: '', service: '', company: '', phone: '', message: '', website: '' });
       } else {
         setStatus('error');
       }
@@ -89,124 +83,60 @@ const ContactPage = () => {
               className="bg-gray-50 p-8 rounded-2xl"
             >
               <h2 className="text-3xl font-bold text-dark mb-6">Send us a message</h2>
-              <form onSubmit={handleSubmit} className="space-y-6">
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              {status === 'success' ? (
+                <div className="space-y-4 text-center">
+                  <p className="text-lg text-gray-700">Thanks! We’ll respond within 24 hours. You can also book directly now.</p>
+                  <Link href="https://calendar.app.google/uYHrdAiAqTZCC6qv9" target="_blank" rel="noopener noreferrer" className="btn-primary inline-block">
+                    Get Your Free Automation Assessment
+                  </Link>
+                </div>
+              ) : (
+                <form onSubmit={handleSubmit} className="space-y-6">
                   <div>
-                    <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-2">
-                      Full Name *
-                    </label>
-                    <input
-                      type="text"
-                      id="name"
-                      name="name"
-                      required
-                      value={formData.name}
-                      onChange={handleChange}
-                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent transition-colors"
-                      placeholder="Your full name"
-                    />
+                    <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-2">Full Name *</label>
+                    <input type="text" id="name" name="name" required value={formData.name} onChange={handleChange} className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent transition-colors" />
                   </div>
                   <div>
-                    <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
-                      Email Address *
-                    </label>
-                    <input
-                      type="email"
-                      id="email"
-                      name="email"
-                      required
-                      value={formData.email}
-                      onChange={handleChange}
-                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent transition-colors"
-                      placeholder="your@email.com"
-                    />
-                  </div>
-                </div>
-
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                  <div>
-                    <label htmlFor="company" className="block text-sm font-medium text-gray-700 mb-2">
-                      Company Name
-                    </label>
-                    <input
-                      type="text"
-                      id="company"
-                      name="company"
-                      value={formData.company}
-                      onChange={handleChange}
-                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent transition-colors"
-                      placeholder="Your company"
-                    />
+                    <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">Email *</label>
+                    <input type="email" id="email" name="email" required value={formData.email} onChange={handleChange} className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent transition-colors" />
                   </div>
                   <div>
-                    <label htmlFor="phone" className="block text-sm font-medium text-gray-700 mb-2">
-                      Phone Number
-                    </label>
-                    <input
-                      type="tel"
-                      id="phone"
-                      name="phone"
-                      value={formData.phone}
-                      onChange={handleChange}
-                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent transition-colors"
-                      placeholder="+1 (555) 000-0000"
-                    />
+                    <label htmlFor="service" className="block text-sm font-medium text-gray-700 mb-2">Service *</label>
+                    <select id="service" name="service" required value={formData.service} onChange={handleChange} className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent transition-colors">
+                      <option value="">Select a service</option>
+                      <option value="workflow-automation">Workflow Automation</option>
+                      <option value="ai-agents">AI Agents</option>
+                      <option value="chatbots">Chatbots</option>
+                      <option value="ecommerce-automation">Ecommerce Automation</option>
+                    </select>
                   </div>
-                </div>
-
-                <div>
-                  <label htmlFor="service" className="block text-sm font-medium text-gray-700 mb-2">
-                    Service Interested In
-                  </label>
-                  <select
-                    id="service"
-                    name="service"
-                    value={formData.service}
-                    onChange={handleChange}
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent transition-colors"
-                  >
-                    <option value="">Select a service</option>
-                    <option value="workflow-automation">Workflow Automation</option>
-                    <option value="ai-agents">AI Agents</option>
-                    <option value="chatbots">Chatbots</option>
-                    <option value="ecommerce-automation">Ecommerce Automation</option>
-                    <option value="custom-solution">Custom Solution</option>
-                    <option value="consultation">Free Consultation</option>
-                  </select>
-                </div>
-
-                <div>
-                  <label htmlFor="message" className="block text-sm font-medium text-gray-700 mb-2">
-                    Message *
-                  </label>
-                  <textarea
-                    id="message"
-                    name="message"
-                    required
-                    rows={5}
-                    value={formData.message}
-                    onChange={handleChange}
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent transition-colors resize-none"
-                    placeholder="Tell us about your business challenges and how we can help..."
-                  ></textarea>
-                </div>
-
-                <button
-                  type="submit"
-                  className="w-full btn-primary text-lg py-4"
-                >
-                  Send Message
-                </button>
-                {status === 'sending' && (
-                  <p className="text-blue-500 mt-2 text-center">Sending...</p>
-                )}
-                {status === 'success' && (
-                  <p className="text-green-600 mt-2 text-center">Message sent successfully!</p>
-                )}
-                {status === 'error' && (
-                  <p className="text-red-600 mt-2 text-center">An error occurred.</p>
-                )}
-              </form>
+                  <button type="button" onClick={() => setDetailsOpen(!detailsOpen)} className="text-primary underline">
+                    {detailsOpen ? 'Hide extra details' : 'Add more details'}
+                  </button>
+                  {detailsOpen && (
+                    <div className="space-y-4">
+                      <div>
+                        <label htmlFor="company" className="block text-sm font-medium text-gray-700 mb-2">Company</label>
+                        <input type="text" id="company" name="company" value={formData.company} onChange={handleChange} className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent transition-colors" />
+                      </div>
+                      <div>
+                        <label htmlFor="phone" className="block text-sm font-medium text-gray-700 mb-2">Phone</label>
+                        <input type="tel" id="phone" name="phone" value={formData.phone} onChange={handleChange} className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent transition-colors" />
+                      </div>
+                      <div>
+                        <label htmlFor="message" className="block text-sm font-medium text-gray-700 mb-2">Message</label>
+                        <textarea id="message" name="message" rows={4} value={formData.message} onChange={handleChange} className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent transition-colors resize-none"></textarea>
+                      </div>
+                    </div>
+                  )}
+                  <input type="text" name="website" value={formData.website} onChange={handleChange} className="hidden" tabIndex={-1} autoComplete="off" />
+                  <button type="submit" className="w-full btn-primary text-lg py-4">
+                    Send Message
+                  </button>
+                  {status === 'sending' && <p className="text-blue-500 mt-2 text-center">Sending...</p>}
+                  {status === 'error' && <p className="text-red-600 mt-2 text-center">An error occurred.</p>}
+                </form>
+              )}
             </motion.div>
 
             {/* Contact Information */}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,7 +24,7 @@
   }
   
   body {
-    @apply bg-white text-gray-900;
+    @apply bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100 leading-relaxed;
     font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   }
 
@@ -35,19 +35,19 @@
 
 @layer components {
   .btn-primary {
-    @apply bg-blue-500 hover:bg-blue-600 text-white font-semibold py-3 px-6 rounded-lg transition-colors duration-200 shadow-lg hover:shadow-xl;
+    @apply bg-blue-500 hover:bg-blue-600 text-white font-semibold py-3 px-6 rounded-lg transition-transform transition-colors duration-200 shadow-lg hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary;
     background-color: var(--color-primary);
   }
-  
+
   .btn-primary:hover {
     background-color: #3182CE;
   }
-  
+
   .btn-secondary {
-    @apply bg-cyan-500 hover:bg-cyan-600 text-white font-semibold py-3 px-6 rounded-lg transition-colors duration-200 shadow-lg hover:shadow-xl;
+    @apply bg-cyan-500 hover:bg-cyan-600 text-white font-semibold py-3 px-6 rounded-lg transition-transform transition-colors duration-200 shadow-lg hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-accent;
     background-color: var(--color-accent);
   }
-  
+
   .btn-secondary:hover {
     background-color: #0891B2;
   }
@@ -90,6 +90,17 @@
 
   .card-hover {
     @apply transition-all duration-300 hover:scale-105 hover:shadow-xl;
+  }
+
+  .neon-text {
+    @apply bg-gradient-to-r from-primary to-accent text-transparent bg-clip-text;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .btn-primary:hover,
+  .btn-secondary:hover {
+    @apply scale-105;
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Montserrat } from "next/font/google";
 import "./globals.css";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
+import StickyCTA from "@/components/StickyCTA";
 
 const montserrat = Montserrat({
   subsets: ["latin"],
@@ -31,11 +32,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="scroll-smooth">
-      <body className={`${montserrat.variable} font-sans antialiased`}>
+      <body className={`${montserrat.variable} font-sans antialiased`}> 
         <Navigation />
         <main className="pt-16 lg:pt-20">
           {children}
         </main>
+        <StickyCTA />
         <Footer />
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,7 +15,7 @@ const HeroSection = () => {
   ];
 
   return (
-    <section className="relative min-h-screen bg-gradient-to-br from-gray-50 to-white pt-28 pb-20">
+    <section className="relative min-h-[80vh] bg-gradient-to-br from-gray-50 to-white pt-24 pb-16">
       {/* Background Elements */}
       <div className="absolute inset-0 overflow-hidden">
         <div className="absolute -top-40 -right-40 w-80 h-80 rounded-full bg-primary/10 blur-3xl"></div>
@@ -30,11 +30,9 @@ const HeroSection = () => {
             initial={{ opacity: 0, y: 50 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8, delay: 0.2 }}
-            className="text-4xl font-bold leading-tight text-dark sm:text-5xl md:text-6xl lg:text-7xl xl:text-8xl"
+            className="text-3xl sm:text-5xl md:text-6xl font-bold leading-tight text-dark"
           >
-            <span className="block">Streamline.</span>
-            <span className="block text-primary">Automate.</span>
-            <span className="block text-accent">Scale.</span>
+            AI-powered automation that saves 15–30 hours per week
           </motion.h1>
 
           {/* Subheadline */}
@@ -42,10 +40,9 @@ const HeroSection = () => {
             initial={{ opacity: 0, y: 30 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8, delay: 0.4 }}
-            className="mx-auto mb-8 max-w-4xl px-4 text-xl leading-relaxed text-gray-600 sm:text-2xl md:text-3xl"
+            className="mx-auto mb-6 max-w-3xl px-4 text-lg leading-relaxed text-gray-600 sm:text-xl"
           >
-            We help digital businesses save time through intelligent AI automation.
-            Stop doing busy work and start focusing on what matters most.
+            Cut busy work, reduce errors by up to 95%, and scale with 24/7 AI. We build practical automations for digital businesses.
           </motion.p>
 
           {/* CTA Buttons */}
@@ -57,14 +54,15 @@ const HeroSection = () => {
           >
             <Link
               href="https://calendar.app.google/uYHrdAiAqTZCC6qv9"
+              id="hero-cta"
               target="_blank"
               rel="noopener noreferrer"
               className="btn-primary px-8 py-4 text-lg"
             >
-              Book a Free Call
+              Get Your Free Automation Assessment
             </Link>
-            <Link href="/services" className="btn-secondary px-8 py-4 text-lg">
-              View Services
+            <Link href="/services" className="text-primary hover:underline text-lg">
+              Explore Services
             </Link>
           </motion.div>
 
@@ -185,30 +183,67 @@ const ServicesSection = () => {
   );
 };
 
-// How It Works Section
-const HowItWorksSection = () => {
+// Case Studies Section
+const CaseStudiesSection = () => {
+  const cases = [
+    {
+      client: 'Ecommerce Brand',
+      problem: 'Manual follow-ups and abandoned carts',
+      solution: 'Automated customer journeys',
+      result: '+25% sales',
+      quote: 'Automation recovered revenue we didn\'t know we were missing.'
+    },
+    {
+      client: 'SaaS Company',
+      problem: 'Hours lost to data entry',
+      solution: 'Workflow automation',
+      result: '15h saved weekly & 95% fewer errors',
+      quote: 'Our team finally focuses on product, not spreadsheets.'
+    },
+    {
+      client: 'Service Agency',
+      problem: 'Leads lost after hours',
+      solution: '24/7 AI agent',
+      result: 'Round-the-clock qualification',
+      quote: 'Clients get answers instantly, even at 2am.'
+    },
+  ];
+
+  return (
+    <section className="section-padding bg-white">
+      <div className="container-custom">
+        <div className="mb-8 text-center">
+          <h2 className="text-4xl md:text-5xl font-bold text-dark mb-6">Proven results</h2>
+        </div>
+        <div className="flex overflow-x-auto space-x-6 pb-4">
+          {cases.map((c, i) => (
+            <div key={i} className="flex-shrink-0 w-80 bg-gray-50 p-6 rounded-2xl shadow-sm hover:shadow-md transition-shadow">
+              <h3 className="font-semibold text-dark mb-2">{c.client}</h3>
+              <p className="text-sm text-gray-600 mb-2">Problem: {c.problem}</p>
+              <p className="text-sm text-gray-600 mb-2">Solution: {c.solution}</p>
+              <p className="text-sm text-gray-600 mb-2">Results: {c.result}</p>
+              <p className="text-gray-700 italic">"{c.quote}"</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+// Process Section
+const ProcessSection = () => {
   const steps = [
-    {
-      step: "01",
-      title: "Analyze",
-      description: "We assess your current workflows and identify automation opportunities."
-    },
-    {
-      step: "02",
-      title: "Automate",
-      description: "Our team builds and implements custom AI solutions tailored to your needs."
-    },
-    {
-      step: "03",
-      title: "Scale",
-      description: "Watch your business grow as automation handles the work while you focus on strategy."
-    }
+    { step: '1', title: 'Discovery Call', description: 'Understand goals and current workflow.' },
+    { step: '2', title: 'Strategy Development', description: 'Design a tailored automation roadmap.' },
+    { step: '3', title: 'Implementation', description: 'Build and integrate your automations.' },
+    { step: '4', title: 'Optimization', description: 'Monitor results and iterate for growth.' },
   ];
 
   return (
     <section className="section-padding bg-gray-50">
       <div className="container-custom">
-        <div className="text-center mb-16">
+        <div className="text-center mb-8">
           <motion.h2
             initial={{ opacity: 0, y: 30 }}
             whileInView={{ opacity: 1, y: 0 }}
@@ -216,34 +251,24 @@ const HowItWorksSection = () => {
             viewport={{ once: true }}
             className="text-4xl md:text-5xl font-bold text-dark mb-6"
           >
-            How It Works
+            Our Process
           </motion.h2>
-          <motion.p
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.2 }}
-            viewport={{ once: true }}
-            className="text-xl text-gray-600 max-w-2xl mx-auto"
-          >
-            Our simple, smart, and scalable process gets you automated fast
-          </motion.p>
         </div>
-
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+        <div className="flex overflow-x-auto md:grid md:grid-cols-4 gap-6">
           {steps.map((step, index) => (
             <motion.div
               key={index}
-              initial={{ opacity: 0, y: 30 }}
+              initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6, delay: index * 0.2 }}
+              transition={{ duration: 0.6, delay: index * 0.1 }}
               viewport={{ once: true }}
-              className="text-center"
+              className="flex-shrink-0 md:flex-shrink text-center md:text-left"
             >
-              <div className="w-20 h-20 bg-primary text-white rounded-full flex items-center justify-center text-2xl font-bold mx-auto mb-6">
-                {step.step}
+              <div className="mb-4 flex items-center justify-center md:justify-start">
+                <span className="w-10 h-10 rounded-full bg-primary text-white flex items-center justify-center font-bold mr-4">{step.step}</span>
+                <h3 className="font-semibold text-dark">{step.title}</h3>
               </div>
-              <h3 className="text-2xl font-bold text-dark mb-4">{step.title}</h3>
-              <p className="text-gray-600 leading-relaxed">{step.description}</p>
+              <p className="text-gray-600 md:ml-14">{step.description}</p>
             </motion.div>
           ))}
         </div>
@@ -369,7 +394,7 @@ const CTASection = () => {
           viewport={{ once: true }}
         >
           <Link href="https://calendar.app.google/uYHrdAiAqTZCC6qv9" target="_blank" rel="noopener noreferrer" className="bg-white text-primary font-semibold py-4 px-8 rounded-lg text-lg hover:bg-gray-100 transition-colors duration-200 shadow-lg hover:shadow-xl">
-            Book Your Free Call
+            Get Your Free Automation Assessment
           </Link>
         </motion.div>
       </div>
@@ -383,7 +408,8 @@ export default function HomePage() {
     <>
       <HeroSection />
       <ServicesSection />
-      <HowItWorksSection />
+      <CaseStudiesSection />
+      <ProcessSection />
       <TestimonialsSection />
       <CTASection />
     </>

--- a/src/app/services/ServicesClientPage.tsx
+++ b/src/app/services/ServicesClientPage.tsx
@@ -6,87 +6,35 @@ import Link from 'next/link';
 
 const ServicesClientPage = () => {
   const services = [
-    {
-      icon: "⚡",
-      title: "Workflow Automation",
-      description: "Streamline your business processes and eliminate manual work",
-      features: [
-        "Data entry automation",
-        "Report generation",
-        "Email workflow automation",
-        "Task scheduling and management",
-        "Integration between tools",
-        "Approval process automation"
-      ],
-      benefits: [
-        "Save 15-30 hours per week",
-        "Reduce errors by 95%",
-        "Improve team productivity",
-        "Scale operations efficiently"
-      ],
-      pricing: "Starting at $2,500"
-    },
-    {
-      icon: "🤖",
-      title: "AI Agents",
-      description: "Intelligent AI agents that work 24/7 to handle complex business tasks",
-      features: [
-        "Customer inquiry handling",
-        "Lead qualification",
-        "Appointment scheduling",
-        "Data analysis and insights",
-        "Content creation assistance",
-        "Multi-language support"
-      ],
-      benefits: [
-        "24/7 availability",
-        "Instant response times",
-        "Consistent quality",
-        "Multilingual capabilities"
-      ],
-      pricing: "Starting at $3,500"
-    },
-    {
-      icon: "💬",
-      title: "Chatbots",
-      description: "Smart chatbots that engage customers and drive conversions",
-      features: [
-        "Website integration",
-        "FAQ automation",
-        "Lead capture",
-        "Product recommendations",
-        "Order status updates",
-        "Support ticket creation"
-      ],
-      benefits: [
-        "Increase conversion rates",
-        "Reduce support workload",
-        "Capture leads 24/7",
-        "Improve customer satisfaction"
-      ],
-      pricing: "Starting at $1,500"
-    },
-    {
-      icon: "🛒",
-      title: "Ecommerce Automation",
-      description: "Optimize your online store with intelligent automation",
-      features: [
-        "Inventory management",
-        "Order processing",
-        "Customer segmentation",
-        "Abandoned cart recovery",
-        "Price optimization",
-        "Review management"
-      ],
-      benefits: [
-        "Increase sales by 25%",
-        "Reduce operational costs",
-        "Improve customer experience",
-        "Scale without hiring"
-      ],
-      pricing: "Starting at $4,000"
-    }
-  ];
+  {
+    icon: '⚡',
+    title: 'Workflow Automation',
+    slug: 'workflow-automation',
+    benefits: ['Save 15-30 hours per week', 'Up to 95% error reduction', '24/7 availability'],
+    details: ['Data entry automation', 'Report generation', 'Email workflow automation', 'Task scheduling'],
+  },
+  {
+    icon: '🤖',
+    title: 'AI Agents',
+    slug: 'ai-agents',
+    benefits: ['24/7 availability', 'Instant response times', 'Consistent quality'],
+    details: ['Customer inquiry handling', 'Lead qualification', 'Appointment scheduling'],
+  },
+  {
+    icon: '💬',
+    title: 'Chatbots',
+    slug: 'chatbots',
+    benefits: ['Increase conversion rates', 'Reduce support workload', 'Capture leads 24/7'],
+    details: ['Website integration', 'FAQ automation', 'Product recommendations'],
+  },
+  {
+    icon: '🛒',
+    title: 'Ecommerce Automation',
+    slug: 'ecommerce-automation',
+    benefits: ['Up to 25% more sales', 'Reduce operational costs', 'Improve customer experience'],
+    details: ['Inventory management', 'Abandoned cart recovery', 'Price optimization'],
+  },
+];
 
   const process = [
     {
@@ -139,11 +87,11 @@ const ServicesClientPage = () => {
             transition={{ duration: 0.6, delay: 0.4 }}
             viewport={{ once: true }}
           >
-            <Link href="/contact" className="btn-primary text-lg">
-              Get Your Custom Quote
+            <Link href="https://calendar.app.google/uYHrdAiAqTZCC6qv9" target="_blank" className="btn-primary text-lg">
+              Get Your Free Automation Assessment
             </Link>
             <p className="mt-4 text-sm text-gray-600">
-              Or <Link href="/contact" className="text-primary hover:underline">schedule a free consultation</Link> to discuss your needs.
+              Or <Link href="/services" className="text-primary hover:underline">explore services</Link> to see more options.
             </p>
           </motion.div>
         </div>
@@ -164,38 +112,25 @@ const ServicesClientPage = () => {
               >
                 <div className="text-5xl mb-6">{service.icon}</div>
                 <h3 className="text-3xl font-bold text-dark mb-4">{service.title}</h3>
-                <p className="text-lg text-gray-600 mb-6">{service.description}</p>
-
-                <div className="mb-6">
-                  <h4 className="text-lg font-semibold text-dark mb-3">Features Include:</h4>
-                  <ul className="space-y-2">
-                    {service.features.map((feature, featureIndex) => (
-                      <li key={featureIndex} className="flex items-center text-gray-700">
-                        <span className="w-2 h-2 bg-primary rounded-full mr-3"></span>
-                        {feature}
-                      </li>
+                <ul className="space-y-2 mb-4">
+                  {service.benefits.map((b, i) => (
+                    <li key={i} className="flex items-center text-gray-700">
+                      <span className="w-2 h-2 bg-accent rounded-full mr-3"></span>{b}
+                    </li>
+                  ))}
+                </ul>
+                <details className="mb-4">
+                  <summary className="cursor-pointer text-primary">Show details</summary>
+                  <ul className="mt-2 space-y-1 pl-4">
+                    {service.details.map((d, i) => (
+                      <li key={i} className="text-gray-600 list-disc">{d}</li>
                     ))}
                   </ul>
-                </div>
-
-                <div className="mb-6">
-                  <h4 className="text-lg font-semibold text-dark mb-3">Key Benefits:</h4>
-                  <ul className="space-y-2">
-                    {service.benefits.map((benefit, benefitIndex) => (
-                      <li key={benefitIndex} className="flex items-center text-gray-700">
-                        <span className="w-2 h-2 bg-accent rounded-full mr-3"></span>
-                        {benefit}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-
-                <div className="border-t border-gray-200 pt-6">
-                  <div className="flex justify-end items-center">
-                    <Link href="/contact" className="btn-secondary">
-                      Learn More
-                    </Link>
-                  </div>
+                </details>
+                <div className="border-t border-gray-200 pt-6 text-right">
+                  <Link href={`/services/${service.slug}`} className="btn-secondary">
+                    Learn More
+                  </Link>
                 </div>
               </motion.div>
             ))}

--- a/src/app/services/[slug]/page.tsx
+++ b/src/app/services/[slug]/page.tsx
@@ -1,0 +1,60 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+const services: Record<string, {title: string; problem: string; solution: string; outcomes: string[]}> = {
+  'workflow-automation': {
+    title: 'Workflow Automation',
+    problem: 'Teams lose hours on repetitive tasks and manual data entry.',
+    solution: 'Automate routine processes so your team can focus on growth.',
+    outcomes: ['Save 15-30 hours per week', 'Up to 95% error reduction'],
+  },
+  'ai-agents': {
+    title: 'AI Agents',
+    problem: 'Leads and customers wait for replies when your team is offline.',
+    solution: 'Deploy always-on AI agents to handle requests instantly.',
+    outcomes: ['24/7 availability', 'Instant response times'],
+  },
+  'chatbots': {
+    title: 'Chatbots',
+    problem: 'Visitors drop off without getting the answers they need.',
+    solution: 'Engage users with conversational bots that guide and capture leads.',
+    outcomes: ['Increase conversion rates', 'Reduce support workload'],
+  },
+  'ecommerce-automation': {
+    title: 'Ecommerce Automation',
+    problem: 'Manual store management limits growth and causes errors.',
+    solution: 'Automate inventory, follow-ups and pricing for scalable sales.',
+    outcomes: ['Up to 25% more sales', 'Lower operational costs'],
+  },
+};
+
+export default function ServicePage({ params }: { params: { slug: string } }) {
+  const service = services[params.slug];
+  if (!service) return notFound();
+  return (
+    <section className="section-padding">
+      <div className="container-custom space-y-8">
+        <h1 className="text-4xl font-bold text-dark">{service.title}</h1>
+        <div>
+          <h2 className="text-xl font-semibold text-dark mb-2">Problem</h2>
+          <p className="text-gray-700">{service.problem}</p>
+        </div>
+        <div>
+          <h2 className="text-xl font-semibold text-dark mb-2">Solution</h2>
+          <p className="text-gray-700">{service.solution}</p>
+        </div>
+        <div>
+          <h2 className="text-xl font-semibold text-dark mb-2">Outcomes</h2>
+          <ul className="list-disc pl-6 text-gray-700">
+            {service.outcomes.map((o, i) => (
+              <li key={i}>{o}</li>
+            ))}
+          </ul>
+        </div>
+        <Link href="https://calendar.app.google/uYHrdAiAqTZCC6qv9" target="_blank" className="btn-primary inline-block">
+          Get Your Free Automation Assessment
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -1,0 +1,32 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+const DarkModeToggle = () => {
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    const prefersDark = stored ? stored === 'dark' : window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.classList.toggle('dark', prefersDark);
+    setEnabled(prefersDark);
+  }, []);
+
+  const toggle = () => {
+    const next = !enabled;
+    document.documentElement.classList.toggle('dark', next);
+    localStorage.setItem('theme', next ? 'dark' : 'light');
+    setEnabled(next);
+  };
+
+  return (
+    <button
+      aria-label="Toggle dark mode"
+      onClick={toggle}
+      className="p-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700"
+    >
+      {enabled ? '🌙' : '☀️'}
+    </button>
+  );
+};
+
+export default DarkModeToggle;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
 import Logo from './Logo';
+import DarkModeToggle from './DarkModeToggle';
 
 const Navigation: React.FC = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -12,7 +13,6 @@ const Navigation: React.FC = () => {
     { name: 'Home', href: '/' },
     { name: 'About', href: '/about' },
     { name: 'Services', href: '/services' },
-    { name: 'Contact', href: '/contact' },
   ];
 
   return (
@@ -37,10 +37,11 @@ const Navigation: React.FC = () => {
             ))}
           </div>
 
-          {/* CTA Button */}
+          {/* CTA Button & Dark mode */}
           <div className="hidden md:flex items-center space-x-4">
+            <DarkModeToggle />
             <Link href="https://calendar.app.google/uYHrdAiAqTZCC6qv9" target="_blank" rel="noopener noreferrer" className="btn-primary">
-              Book a Call
+              Get Your Free Automation Assessment
             </Link>
           </div>
 
@@ -77,15 +78,18 @@ const Navigation: React.FC = () => {
                   {item.name}
                 </Link>
               ))}
-              <Link 
-                href="https://calendar.app.google/uYHrdAiAqTZCC6qv9"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="btn-primary mt-4 text-center"
-                onClick={() => setIsMenuOpen(false)}
-              >
-                Book a Call
-              </Link>
+              <div className="flex items-center justify-between pt-4 border-t border-gray-200">
+                <DarkModeToggle />
+                <Link
+                  href="https://calendar.app.google/uYHrdAiAqTZCC6qv9"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="btn-primary text-center flex-1 ml-4"
+                  onClick={() => setIsMenuOpen(false)}
+                >
+                  Get Your Free Automation Assessment
+                </Link>
+              </div>
             </div>
           </motion.div>
         )}

--- a/src/components/StickyCTA.tsx
+++ b/src/components/StickyCTA.tsx
@@ -1,0 +1,51 @@
+'use client';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+const StickyCTA = () => {
+  const pathname = usePathname();
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    const hero = document.getElementById('hero-cta');
+    if (!hero) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => setHidden(entry.isIntersecting),
+      { threshold: 0.5 }
+    );
+    observer.observe(hero);
+    return () => observer.disconnect();
+  }, [pathname]);
+
+  const href = 'https://calendar.app.google/uYHrdAiAqTZCC6qv9';
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (pathname === '/') {
+      const el = document.getElementById('hero-cta');
+      if (el) {
+        e.preventDefault();
+        el.scrollIntoView({ behavior: 'smooth' });
+      }
+    }
+  };
+
+  return (
+    <div
+      className={`${hidden ? 'opacity-0 pointer-events-none' : 'opacity-100'} fixed inset-x-0 bottom-0 z-40 md:inset-auto md:right-6 md:bottom-6 md:w-auto transition-opacity pb-[env(safe-area-inset-bottom)]`}
+    >
+      <Link
+        href={href}
+        onClick={handleClick}
+        className="block w-full md:w-auto text-center btn-primary rounded-none md:rounded-full py-4 md:py-2 md:px-4"
+        target={pathname === '/' ? undefined : '_blank'}
+        rel="noopener noreferrer"
+        id="sticky-cta"
+      >
+        Get Your Free Automation Assessment
+      </Link>
+    </div>
+  );
+};
+
+export default StickyCTA;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
@@ -18,4 +19,4 @@ module.exports = {
     },
   },
   plugins: [],
-} 
+};


### PR DESCRIPTION
## Summary
- Revamp navigation and layout with dark mode toggle, unified “Get Your Free Automation Assessment” CTA, and sticky floating CTA
- Refresh home page hero, add case studies carousel and process timeline
- Simplify services and contact pages with scannable cards, dynamic service routes, and streamlined inquiry form

## Testing
- `npm run dev`
- `npm run build` *(fails: Failed to fetch Montserrat font from Google)*

------
https://chatgpt.com/codex/tasks/task_e_6895b6a096d48325917e94b662cd8fd9